### PR TITLE
Add Support for Kopernicus

### DIFF
--- a/GameData/MunSeeker/ZZZ_RadioTelescope/MunSeeker_ZZZ_RadioTelescope_Contracts.cfg
+++ b/GameData/MunSeeker/ZZZ_RadioTelescope/MunSeeker_ZZZ_RadioTelescope_Contracts.cfg
@@ -146,6 +146,12 @@ CONTRACT_TYPE
                 // Minimum count, default = 1
                 minCount = 1
             }
+            REQUIREMENT:NEEDS[Kopernicus]
+	        {
+	            name = PartValidationKopernicus
+	            type = PartModuleUnlocked
+	            partModule = KopernicusSolarPanel
+	        }
 			PARAMETER:NEEDS[NearFutureSolar]
 			{
 				name = PartValidationNearFutureSolar
@@ -227,6 +233,12 @@ CONTRACT_TYPE
 			type = PartModuleUnlocked
 			partModule = ModuleDeployableSolarPanel
 		}
+        REQUIREMENT:NEEDS[Kopernicus]
+        {
+            name = PartValidationKopernicus
+            type = PartModuleUnlocked
+            partModule = KopernicusSolarPanel
+        }
 		REQUIREMENT:NEEDS[NearFutureSolar]
 		{
 			name = PartModuleUnlocked
@@ -367,6 +379,12 @@ CONTRACT_TYPE
                 // Minimum count, default = 1
                 minCount = 1
             }
+            REQUIREMENT:NEEDS[Kopernicus]
+	        {
+	            name = PartValidationKopernicus
+	            type = PartModuleUnlocked
+	            partModule = KopernicusSolarPanel
+	        }
 			PARAMETER:NEEDS[NearFutureSolar]
 			{
 				name = PartValidationNearFutureSolar
@@ -448,6 +466,12 @@ CONTRACT_TYPE
 			type = PartModuleUnlocked
 			partModule = ModuleDeployableSolarPanel
 		}
+        REQUIREMENT:NEEDS[Kopernicus]
+        {
+            name = PartValidationKopernicus
+            type = PartModuleUnlocked
+            partModule = KopernicusSolarPanel
+        }
 		REQUIREMENT:NEEDS[NearFutureSolar]
 		{
 			name = PartModuleUnlocked


### PR DESCRIPTION
Kopernicus overwrites solar panel modules so without these the contracts will not activate.